### PR TITLE
絵文字など特殊文字に対応

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -36,3 +36,4 @@ services:
       - MARIADB_DATABASE=${DATABASE_NAME}
     volumes:
       - zoomail_database_data:/var/lib/mysql:Z
+      - ./mysql.cnf:/etc/mysql/conf.d/mysql.cnf

--- a/mysql.cnf
+++ b/mysql.cnf
@@ -1,0 +1,8 @@
+[mysql]
+default-character-set=utf8mb4
+
+[mysqld]
+
+collation-server = utf8mb4_unicode_ci
+init-connect='SET NAMES utf8mb4'
+character-set-server = utf8mb4


### PR DESCRIPTION
RDBの文字コード指定を追加
uft8mb4を利用する